### PR TITLE
Added enabledstate component, optimize theme, fixed issue in state.tx…

### DIFF
--- a/src/pages/sidepanel/State.tsx
+++ b/src/pages/sidepanel/State.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Button, Stack, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import { domainStore, ExtensionState } from '@src/shared/storages/extensionDomainStorage';
 import TopNavigation from '@root/src/pages/sidepanel/components/TopNavigation';
 import { DisabledState } from '@root/src/pages/sidepanel/components/DisabledState';
-import { WrongDomain } from '@root/src/pages/sidepanel/assets/svg/wrongDomainIcon';
+import { EnabledState } from '@root/src/pages/sidepanel/components/EnabledState';
 import useStorage from '@src/shared/hooks/useStorage';
 import { useDisabledState } from '@root/src/pages/sidepanel/hooks/useDisabledState';
 import { appContent } from '@root/src/shared/content/appContent';
@@ -103,15 +103,7 @@ const State: React.FC<React.PropsWithChildren<StateProps>> = () => {
   };
 
   return (
-    <Box
-      width="100%"
-      height="100vh"
-      display="flex"
-      overflow={'hidden'}
-      flexDirection="column"
-      sx={{
-        background: '#E9E8EE',
-      }}>
+    <Box width="100%" height="100vh" display="flex" overflow={'hidden'} flexDirection="column">
       <TopNavigation isEnabled={isEnabled} onChange={handleStateToggle} />
 
       {isEnabled ? (
@@ -121,25 +113,12 @@ const State: React.FC<React.PropsWithChildren<StateProps>> = () => {
               <SidePanel key={resetSidePanel} isEnabled={isEnabled} />
             </>
           ) : (
-            <Stack display={'flex'} justifyContent={'center'} alignItems={'center'} height={'100%'} p={5} spacing={1}>
-              <WrongDomain />
-              <Typography variant={'body1'} align={'center'} pb={2} maxWidth={'450px'}>
-                {domainState.pinnedURL ? (
-                  <>
-                    Wait a minute! You are currently analyzing <strong>{domainState.pinnedURL}</strong>
-                    {tabValid ? '' : ' in another tab'}. If you&apos;d like to analyze this domain instead pin it below.
-                  </>
-                ) : (
-                  <>
-                    You are not currently analyzing a domain. To get started, navigate to your preferred domain and pin
-                    it below.
-                  </>
-                )}
-              </Typography>
-              <Button size={'small'} color={'secondary'} variant="outlined" onClick={handlePin}>
-                Pin Domain
-              </Button>
-            </Stack>
+            <EnabledState
+              domainState={domainState}
+              tabValid={tabValid}
+              onPin={handlePin}
+              documentationUrl={documentationUrl}
+            />
           )}
         </Box>
       ) : (

--- a/src/pages/sidepanel/assets/svg/ConfigDomain.tsx
+++ b/src/pages/sidepanel/assets/svg/ConfigDomain.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export const ConfigDomain = () => (
+  <svg width="75" height="60" viewBox="0 0 75 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M4.62598 1.33984H70.374C71.882 1.33994 73.1044 2.56232 73.1045 4.07031V50.2529C73.1045 51.761 71.882 52.9833 70.374 52.9834H4.62598C3.11793 52.9833 1.89551 51.761 1.89551 50.2529V4.07031C1.89558 2.5623 3.11797 1.33991 4.62598 1.33984Z"
+      fill="white"
+    />
+    <path
+      d="M4.62598 1.33984H70.374C71.882 1.33994 73.1044 2.56232 73.1045 4.07031V50.2529C73.1045 51.761 71.882 52.9833 70.374 52.9834H4.62598C3.11793 52.9833 1.89551 51.761 1.89551 50.2529V4.07031C1.89558 2.5623 3.11797 1.33991 4.62598 1.33984Z"
+      stroke="#C7C7C8"
+      strokeWidth="2.16"
+    />
+    <rect x="24" y="6.45898" width="44.28" height="3.24" rx="1.62" fill="#C7C7C8" />
+    <rect x="5.89606" y="6.22959" width="3.46939" height="3.46939" rx="1.7347" fill="#C7C7C8" />
+    <rect x="10.7533" y="6.22959" width="3.46939" height="3.46939" rx="1.7347" fill="#C7C7C8" />
+    <rect x="15.6102" y="6.22959" width="3.46939" height="3.46939" rx="1.7347" fill="#C7C7C8" />
+    <foreignObject x="13.2" y="18.2" width="47.6" height="47.6">
+      <div
+        style={{
+          backdropFilter: 'blur(2.9px)',
+          clipPath: 'url(#bgblur_0_53_390_clip_path)',
+          height: '100%',
+          width: '100%',
+        }}></div>
+    </foreignObject>
+    <circle data-figma-bg-blur-radius="5.8" cx="37" cy="42" r="18" fill="#8848F9" fillOpacity="0.12" />
+    <path d="M37 32V44" stroke="#8848F9" strokeWidth="5" strokeLinecap="round" />
+    <circle cx="37" cy="52" r="3" fill="#8848F9" />
+    <defs>
+      <clipPath id="bgblur_0_53_390_clip_path" transform="translate(-13.2 -18.2)">
+        <circle cx="37" cy="42" r="18" />
+      </clipPath>
+    </defs>
+  </svg>
+);

--- a/src/pages/sidepanel/components/DisabledState.tsx
+++ b/src/pages/sidepanel/components/DisabledState.tsx
@@ -127,18 +127,15 @@ const Title = styled(Typography)(() => ({
 
 const Description = styled(Typography)(() => ({
   lineHeight: appColors.common.lineHeight.tight,
-}));
-
-const DocText = styled(Typography)(() => ({
-  lineHeight: appColors.common.lineHeight.tight,
+  fontSize: appColors.common.fontSize.small,
+  color: appColors.common.colors.textSecondary,
+  fontWeight: appColors.common.fontWeight.medium,
 }));
 
 const StyledLink = styled(Link)(() => ({
   textDecoration: 'underline',
   cursor: 'pointer',
-  '&:hover': {
-    textDecoration: 'none',
-  },
+  color: appColors.common.colors.textSecondary,
 }));
 
 export const DisabledState = ({
@@ -168,25 +165,21 @@ export const DisabledState = ({
 
           <StyledCard>
             <Stack spacing={1} alignItems="center" textAlign="center">
-              <Title variant="h6" align="center">
-                {title}
-              </Title>
-              <Description variant="body2" color="text.secondary" align="center">
-                {description}
-              </Description>
+              <Title variant="h6">{title}</Title>
+              <Description>{description}</Description>
             </Stack>
           </StyledCard>
         </Stack>
       </OuterCard>
 
       <DocCard>
-        <DocText variant="body2" color="text.secondary" align="center">
+        <Description>
           {documentationText}{' '}
-          <StyledLink variant="body2" href={documentationUrl} target="_blank" onClick={onDocLinkClick}>
+          <StyledLink href={documentationUrl} target="_blank" onClick={onDocLinkClick}>
             {documentationLinkText}
           </StyledLink>
           {documentationSuffix}
-        </DocText>
+        </Description>
       </DocCard>
     </Container>
   );

--- a/src/pages/sidepanel/components/EnabledState.tsx
+++ b/src/pages/sidepanel/components/EnabledState.tsx
@@ -5,6 +5,9 @@ import { styled } from '@mui/material/styles';
 import { appColors } from '@root/src/theme/palette';
 import { appContent } from '@root/src/shared/content/appContent';
 
+// Extract the type from appContent for better type safety
+type EnabledStateTextContent = typeof appContent.enabledState;
+
 interface EnabledStateProps {
   domainState: {
     pinnedURL: string;
@@ -12,6 +15,8 @@ interface EnabledStateProps {
   tabValid: boolean;
   onPin: () => void;
   documentationUrl: string;
+  // Optional: allow overriding content (useful for testing/customization)
+  textContent?: EnabledStateTextContent;
 }
 
 const Container = styled(Stack)(({ theme }) => ({
@@ -87,38 +92,42 @@ const StyledLink = styled(Link)(() => ({
   color: appColors.common.colors.textSecondary,
 }));
 
-export const EnabledState = ({ domainState, tabValid, onPin, documentationUrl }: EnabledStateProps): JSX.Element => {
+export const EnabledState = ({
+  domainState,
+  tabValid,
+  onPin,
+  documentationUrl,
+  textContent = appContent.enabledState, // Default to centralized content
+}: EnabledStateProps): JSX.Element => {
   return (
     <Container>
       <OuterCard>
         <ConfigDomain />
         <Title variant="h6" align="center">
-          {appContent.enabledState.title}
+          {textContent.title}
         </Title>
         <Typography variant="body2" color="text.secondary" align="center">
           {domainState.pinnedURL ? (
             <>
-              {appContent.enabledState.pinnedUrlText.prefix}
+              {textContent.pinnedUrlText.prefix}
               <strong>{domainState.pinnedURL}</strong>
-              {tabValid
-                ? appContent.enabledState.pinnedUrlText.suffix
-                : appContent.enabledState.pinnedUrlText.suffixAnotherTab}
+              {tabValid ? textContent.pinnedUrlText.suffix : textContent.pinnedUrlText.suffixAnotherTab}
             </>
           ) : (
             <Description>
-              {appContent.enabledState.noPinnedUrlText}
+              {textContent.noPinnedUrlText}
               <StyledLink variant="body2" href={documentationUrl} target="_blank">
-                {appContent.enabledState.documentationLinkText}.
+                {textContent.documentationLinkText}.
               </StyledLink>
             </Description>
           )}
         </Typography>
         <StyledButton size={'medium'} variant="outlined" onClick={onPin}>
-          {appContent.enabledState.buttonText}
+          {textContent.buttonText}
         </StyledButton>
       </OuterCard>
       <DocCard>
-        <DocText align="center">{appContent.enabledState.adBlockerNotice}</DocText>
+        <DocText align="center">{textContent.adBlockerNotice}</DocText>
       </DocCard>
     </Container>
   );

--- a/src/pages/sidepanel/components/EnabledState.tsx
+++ b/src/pages/sidepanel/components/EnabledState.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { Button, Stack, Typography, Card, Link } from '@mui/material';
+import { ConfigDomain } from '../assets/svg/ConfigDomain';
+import { styled } from '@mui/material/styles';
+import { appColors } from '@root/src/theme/palette';
+import { appContent } from '@root/src/shared/content/appContent';
+
+interface EnabledStateProps {
+  domainState: {
+    pinnedURL: string;
+  };
+  tabValid: boolean;
+  onPin: () => void;
+  documentationUrl: string;
+}
+
+const Container = styled(Stack)(({ theme }) => ({
+  height: '100%',
+  padding: theme.spacing(1.5),
+  gap: theme.spacing(3),
+}));
+
+const StyledCard = styled(Card)(({ theme }) => ({
+  width: '100%',
+  padding: theme.spacing(2),
+  backgroundColor: appColors.common.white,
+  borderRadius: theme.spacing(1),
+  boxShadow: 'none',
+  border: 'none',
+  cursor: 'default',
+  transition: 'none',
+  '&:hover': {
+    boxShadow: 'none',
+    transform: 'none',
+  },
+}));
+
+const OuterCard = styled(StyledCard)(({ theme }) => ({
+  padding: `${theme.spacing(4)} ${theme.spacing(4)} ${theme.spacing(4)} ${theme.spacing(4)}`,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  textAlign: 'center',
+  gap: theme.spacing(2),
+}));
+
+const DocCard = styled(StyledCard)(({ theme }) => ({
+  padding: theme.spacing(2.5),
+  fontWeight: appColors.common.fontWeight.semiBold,
+}));
+
+const DocText = styled(Typography)(() => ({
+  lineHeight: appColors.common.lineHeight.tight,
+  fontSize: appColors.common.fontSize.small,
+  color: appColors.common.colors.textSecondary,
+  fontWeight: appColors.common.fontWeight.semiBold,
+}));
+
+const Title = styled(Typography)(() => ({
+  fontSize: appColors.common.fontSize.base,
+  fontWeight: appColors.common.fontWeight.semiBold,
+}));
+
+const Description = styled(Typography)(() => ({
+  lineHeight: appColors.common.lineHeight.tight,
+  fontSize: appColors.common.fontSize.small,
+  color: appColors.common.colors.textSecondary,
+  fontWeight: appColors.common.fontWeight.medium,
+}));
+
+const StyledButton = styled(Button)(() => ({
+  color: appColors.common.colors.accent,
+  borderColor: appColors.common.colors.accent,
+  borderWidth: '0.0625rem',
+  fontWeight: appColors.common.fontWeight.bold,
+  fontSize: appColors.common.fontSize.baseSmall,
+  lineHeight: 1.55,
+  '&:hover': {
+    backgroundColor: 'transparent',
+    borderColor: appColors.common.colors.accent,
+  },
+}));
+
+const StyledLink = styled(Link)(() => ({
+  textDecoration: 'underline',
+  cursor: 'pointer',
+  color: appColors.common.colors.textSecondary,
+}));
+
+export const EnabledState = ({ domainState, tabValid, onPin, documentationUrl }: EnabledStateProps): JSX.Element => {
+  return (
+    <Container>
+      <OuterCard>
+        <ConfigDomain />
+        <Title variant="h6" align="center">
+          {appContent.enabledState.title}
+        </Title>
+        <Typography variant="body2" color="text.secondary" align="center">
+          {domainState.pinnedURL ? (
+            <>
+              {appContent.enabledState.pinnedUrlText.prefix}
+              <strong>{domainState.pinnedURL}</strong>
+              {tabValid
+                ? appContent.enabledState.pinnedUrlText.suffix
+                : appContent.enabledState.pinnedUrlText.suffixAnotherTab}
+            </>
+          ) : (
+            <Description>
+              {appContent.enabledState.noPinnedUrlText}
+              <StyledLink variant="body2" href={documentationUrl} target="_blank">
+                {appContent.enabledState.documentationLinkText}.
+              </StyledLink>
+            </Description>
+          )}
+        </Typography>
+        <StyledButton size={'medium'} variant="outlined" onClick={onPin}>
+          {appContent.enabledState.buttonText}
+        </StyledButton>
+      </OuterCard>
+      <DocCard>
+        <DocText align="center">{appContent.enabledState.adBlockerNotice}</DocText>
+      </DocCard>
+    </Container>
+  );
+};

--- a/src/shared/content/appContent.ts
+++ b/src/shared/content/appContent.ts
@@ -16,6 +16,21 @@ export const appContent = {
     documentationSuffix: '.',
   },
 
+  // EnabledState Component
+  enabledState: {
+    title: 'Configured domain not detected',
+    buttonText: 'Configure domains',
+    pinnedUrlText: {
+      prefix: 'Wait a minute! You are currently analyzing ',
+      suffix: ". If you'd like to analyze this domain instead pin it below.",
+      suffixAnotherTab: " in another tab. If you'd like to analyze this domain instead pin it below.",
+    },
+    documentationLinkText: 'documentation',
+    noPinnedUrlText:
+      "To analyze this domain, add it to your configured domains list. If you haven't yet installed the Lytics tag, please refer to our Lytics JavaScript SDK ",
+    adBlockerNotice: 'Using an Ad Blocker? You may need to disable it temporarily to use this extension.',
+  },
+
   // TopNavigation Component
   topNavigation: {
     enableLabel: 'Enable Extension',

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -22,7 +22,7 @@ const appColors = {
     100: '#f5f5f5',
     200: '#525252',
     400: '#a3a3a3',
-    600: '#525252',
+    600: '#383838',
     900: '#171717',
   },
 
@@ -46,13 +46,20 @@ const appColors = {
     fontFamily: 'SF Pro, -apple-system, BlinkMacSystemFont, sans-serif',
     fontSize: {
       base: '1rem', // Standard font size (16px)
+      baseSmall: '0.875rem', // Standard font size (14px)
+      small: '0.8125rem', // Small font size (13px)
     },
     lineHeight: {
       tight: 1.3, // Tight line height for descriptions
     },
     fontWeight: {
+      medium: 500, // Medium weight
       semiBold: 600, // Semi-bold weight for titles
       bold: 700, // Bold weight for emphasis
+    },
+    colors: {
+      textSecondary: '#7D7A7A', // Secondary text color
+      accent: '#8848F9', // Accent color for buttons and links
     },
   },
 


### PR DESCRIPTION
Closes #71 
**Key Changes:**
	•	Extracted the enabled domain state into a new EnabledState component for cleaner, modular code.
	•	Added a new ConfigDomain SVG illustration for the configured state.
	•	Improved typography, buttons, and links in both EnabledState and DisabledState for consistency.
	•	Centralized enabled state text in appContent.ts for easier management.
	•	Cleaned up unused imports and redundant styles in State.tsx.
	
QA Steps
🧪 Functional Tests
[ ] No Pinned Domain: Verify "Configured domain not detected" message and "Configure domains" button appear
[ ] Pinned Domain (Same Tab): Check "currently analyzing [domain]" message displays correctly
[ ] Pinned Domain (Different Tab): Verify "in another tab" suffix appears
[ ] Configure Button: Click button pins domain, reloads tab, and transitions to main panel
[ ] Documentation Link: Verify link opens Lytics SDK docs in new tab
[ ] Ad Blocker Notice: Confirm notice displays at bottom in all scenarios

UX changes/ impacted page
<img width="223" height="564" alt="image" src="https://github.com/user-attachments/assets/fa8f0af0-5604-4b7d-81ba-473e4651ae1d" />
