### PR TITLE
feat: added last activity section

### DIFF
--- a/src/pages/sidepanel/SidePanel.tsx
+++ b/src/pages/sidepanel/SidePanel.tsx
@@ -26,7 +26,8 @@ const SidePanel: React.FC<SidePanelProps> = ({ key, isEnabled }) => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { tagConfig: currentTabTagConfig, profile: currentTabProfile, domainState } = useCurrentTabState();
+  // Get per-tab state from hook
+  const { tagConfig: currentTabTagConfig, profile: currentTabProfile, domainState, tagActivity } = useCurrentTabState();
 
   const [isLoading, setIsLoading] = useState(true);
   const [profileIsLoading, setProfileIsLoading] = useState(false);
@@ -143,7 +144,10 @@ const SidePanel: React.FC<SidePanelProps> = ({ key, isEnabled }) => {
                   />
                 }
               />
-              <Route path="*" element={<TagStatus tagIsInstalled={tagIsInstalled} tagConfig={tagConfig} />} />
+              <Route
+                path="*"
+                element={<TagStatus tagIsInstalled={tagIsInstalled} tagConfig={tagConfig} tagActivity={tagActivity} />}
+              />
             </Routes>
           </Box>
           <BottomNavigation value={activePath} onChange={newValue => handleNavigation(newValue)} />

--- a/src/pages/sidepanel/sections/TagStatus.test.tsx
+++ b/src/pages/sidepanel/sections/TagStatus.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 import { ThemeProvider } from '@mui/material/styles';
 import { TagConfigModel } from '@root/src/shared/models/tagConfigModel';
+import { EventModel } from '@root/src/shared/models/eventModel';
 import { appTheme } from '@root/src/theme';
 import { render, screen } from '@testing-library/react';
 
@@ -34,16 +35,24 @@ describe('TagStatus', () => {
     loadid: false,
   };
 
+  const mockTagActivity: EventModel[] = [
+    { ts: Date.now() - 5 * 60 * 1000, type: 'load-js-tag', description: 'Loaded JS tag' },
+    { ts: Date.now() - 2 * 60 * 1000, type: 'collect-data', description: 'Collected data' },
+    { ts: Date.now() - 1 * 60 * 1000, type: 'load-profile', description: 'Loaded profile' },
+  ];
+
+  const emptyTagActivity: EventModel[] = [];
+
   describe('when tag is installed', () => {
     it('renders status header correctly', () => {
-      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={mockTagConfig} />);
+      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={mockTagConfig} tagActivity={mockTagActivity} />);
 
       expect(screen.getByText('Status')).toBeInTheDocument();
       expect(screen.getByTestId('MonitorHeartOutlinedIcon')).toBeInTheDocument();
     });
 
     it('shows SDK installed message for current version', () => {
-      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={mockTagConfig} />);
+      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={mockTagConfig} tagActivity={mockTagActivity} />);
 
       expect(screen.getByText('Lytics JavaScript SDK Installed')).toBeInTheDocument();
       expect(screen.getByText('v4.2.1')).toBeInTheDocument();
@@ -51,7 +60,7 @@ describe('TagStatus', () => {
     });
 
     it('shows deprecated version warning for legacy tag', () => {
-      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={legacyTagConfig} />);
+      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={legacyTagConfig} tagActivity={mockTagActivity} />);
 
       expect(screen.getByText('You are using a deprecated version of the Lytics SDK')).toBeInTheDocument();
       expect(screen.getByText('v2.8.5')).toBeInTheDocument();
@@ -59,7 +68,7 @@ describe('TagStatus', () => {
     });
 
     it('renders configuration table with correct data', () => {
-      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={mockTagConfig} />);
+      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={mockTagConfig} tagActivity={mockTagActivity} />);
 
       expect(screen.getByText('Account ID')).toBeInTheDocument();
       expect(screen.getByText('Stream')).toBeInTheDocument();
@@ -77,28 +86,51 @@ describe('TagStatus', () => {
     it('shows disabled for 3rd party cookies when loadid is false', () => {
       const configWithoutLoadid = { ...mockTagConfig, loadid: false };
 
-      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={configWithoutLoadid} />);
+      renderWithTheme(
+        <TagStatus tagIsInstalled={true} tagConfig={configWithoutLoadid} tagActivity={mockTagActivity} />,
+      );
 
       expect(screen.getByText('Disabled')).toBeInTheDocument();
+    });
+
+    it('renders activity table with Last Activity and Data Collection', () => {
+      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={mockTagConfig} tagActivity={mockTagActivity} />);
+
+      expect(screen.getByText('Last Activity')).toBeInTheDocument();
+      expect(screen.getByText('Data Collection')).toBeInTheDocument();
+    });
+
+    it('shows "No activity yet" when tagActivity is empty', () => {
+      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={mockTagConfig} tagActivity={emptyTagActivity} />);
+
+      expect(screen.getByText('No activity yet')).toBeInTheDocument();
+    });
+
+    it('shows activity timestamp as relative time when activity exists', () => {
+      renderWithTheme(<TagStatus tagIsInstalled={true} tagConfig={mockTagConfig} tagActivity={mockTagActivity} />);
+
+      // Should show relative time like "a minute ago" or "2 minutes ago"
+      const activityText = screen.getByText(/ago|minute/i);
+      expect(activityText).toBeInTheDocument();
     });
   });
 
   describe('when tag is not installed', () => {
     it('shows loading spinner', () => {
-      renderWithTheme(<TagStatus tagIsInstalled={false} tagConfig={mockTagConfig} />);
+      renderWithTheme(<TagStatus tagIsInstalled={false} tagConfig={mockTagConfig} tagActivity={emptyTagActivity} />);
 
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
 
     it('shows searching message', () => {
-      renderWithTheme(<TagStatus tagIsInstalled={false} tagConfig={mockTagConfig} />);
+      renderWithTheme(<TagStatus tagIsInstalled={false} tagConfig={mockTagConfig} tagActivity={emptyTagActivity} />);
 
       expect(screen.getByText('Searching for Lytics JavaScript SDK')).toBeInTheDocument();
       expect(screen.getByTestId('ErrorIcon')).toBeInTheDocument();
     });
 
     it('shows installation instructions with documentation link', () => {
-      renderWithTheme(<TagStatus tagIsInstalled={false} tagConfig={mockTagConfig} />);
+      renderWithTheme(<TagStatus tagIsInstalled={false} tagConfig={mockTagConfig} tagActivity={emptyTagActivity} />);
 
       expect(screen.getByText(/We have not been able to find the Lytics JavaScript SDK/)).toBeInTheDocument();
 

--- a/src/pages/sidepanel/sections/TagStatus.tsx
+++ b/src/pages/sidepanel/sections/TagStatus.tsx
@@ -6,11 +6,14 @@ import { styled } from '@mui/material/styles';
 import SimpleTable from '@root/src/pages/sidepanel/components/SimpleTable';
 import { appContent } from '@root/src/shared/content/appContent';
 import { TagConfigModel } from '@root/src/shared/models/tagConfigModel';
+import { EventModel } from '@root/src/shared/models/eventModel';
 import { appColors } from '@root/src/theme/palette';
+import { formatLastActivity, getLastActivityTimestamp } from '@root/src/pages/sidepanel/utils/tagActivityHelpers';
 
 interface TagStatusProps {
   tagIsInstalled: boolean;
   tagConfig: TagConfigModel;
+  tagActivity: EventModel[];
   textContent?: typeof appContent.tagStatus;
 }
 
@@ -106,7 +109,12 @@ const StyledDescriptionTypography = styled(Typography)(({ theme }) => ({
   padding: theme.spacing(1),
 }));
 
-const TagStatus: React.FC<TagStatusProps> = ({ tagIsInstalled, tagConfig, textContent = appContent.tagStatus }) => {
+const TagStatus: React.FC<TagStatusProps> = ({
+  tagIsInstalled,
+  tagConfig,
+  tagActivity,
+  textContent = appContent.tagStatus,
+}) => {
   const [legacyTag, setLegacyTag] = useState(false);
 
   useEffect(() => {
@@ -117,6 +125,10 @@ const TagStatus: React.FC<TagStatusProps> = ({ tagIsInstalled, tagConfig, textCo
       }
     }
   }, [tagConfig]);
+
+  // Calculate last activity time
+  const lastActivityTimestamp = getLastActivityTimestamp(tagActivity);
+  const lastActivityText = formatLastActivity(lastActivityTimestamp);
 
   return (
     <StyledContainer>
@@ -159,6 +171,14 @@ const TagStatus: React.FC<TagStatusProps> = ({ tagIsInstalled, tagConfig, textCo
                   label: textContent.tableLabels.thirdPartyCookies,
                   value: tagConfig?.loadid ? textContent.tableLabels.enabled : textContent.tableLabels.disabled,
                 },
+              ]}
+            />
+          </StyledTableContainer>
+          <StyledTableContainer>
+            <SimpleTable
+              rows={[
+                { label: textContent.tableLabels.lastActivity, value: lastActivityText },
+                { label: textContent.tableLabels.dataCollection, value: textContent.tableLabels.active },
               ]}
             />
           </StyledTableContainer>

--- a/src/pages/sidepanel/utils/tagActivityHelpers.test.ts
+++ b/src/pages/sidepanel/utils/tagActivityHelpers.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { formatLastActivity, getLastActivityTimestamp } from './tagActivityHelpers';
+import { EventModel } from '@root/src/shared/models/eventModel';
+
+describe('tagActivityHelpers', () => {
+  describe('formatLastActivity', () => {
+    it('should return "No activity yet" when timestamp is undefined', () => {
+      expect(formatLastActivity(undefined)).toBe('No activity yet');
+    });
+
+    it('should format timestamp as relative time', () => {
+      const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+      const result = formatLastActivity(fiveMinutesAgo);
+      expect(result).toContain('minutes ago');
+    });
+
+    it('should format recent timestamp correctly', () => {
+      const fewSecondsAgo = Date.now() - 10 * 1000;
+      const result = formatLastActivity(fewSecondsAgo);
+      expect(result).toContain('seconds ago');
+    });
+
+    it('should format old timestamp correctly', () => {
+      const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000;
+      const result = formatLastActivity(twoDaysAgo);
+      expect(result).toContain('days ago');
+    });
+  });
+
+  describe('getLastActivityTimestamp', () => {
+    it('should return undefined when tagActivity is empty array', () => {
+      expect(getLastActivityTimestamp([])).toBeUndefined();
+    });
+
+    it('should return undefined when tagActivity is null', () => {
+      expect(getLastActivityTimestamp(null as any)).toBeUndefined();
+    });
+
+    it('should return undefined when tagActivity is undefined', () => {
+      expect(getLastActivityTimestamp(undefined as any)).toBeUndefined();
+    });
+
+    it('should return the most recent timestamp from single event', () => {
+      const events: EventModel[] = [
+        {
+          ts: 1000000,
+          type: 'collect-data',
+          description: 'Test event',
+        },
+      ];
+
+      expect(getLastActivityTimestamp(events)).toBe(1000000);
+    });
+
+    it('should return the most recent timestamp from multiple events', () => {
+      const events: EventModel[] = [
+        { ts: 1000000, type: 'load-js-tag', description: 'First' },
+        { ts: 3000000, type: 'collect-data', description: 'Third (most recent)' },
+        { ts: 2000000, type: 'load-profile', description: 'Second' },
+      ];
+
+      expect(getLastActivityTimestamp(events)).toBe(3000000);
+    });
+
+    it('should handle events with same timestamp', () => {
+      const events: EventModel[] = [
+        { ts: 1000000, type: 'load-js-tag', description: 'First' },
+        { ts: 1000000, type: 'collect-data', description: 'Second' },
+      ];
+
+      expect(getLastActivityTimestamp(events)).toBe(1000000);
+    });
+  });
+});

--- a/src/pages/sidepanel/utils/tagActivityHelpers.ts
+++ b/src/pages/sidepanel/utils/tagActivityHelpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure utility functions for tag activity operations
+ * These functions are easily testable and have no side effects
+ */
+
+import moment from 'moment';
+import { EventModel } from '@root/src/shared/models/eventModel';
+
+/**
+ * Formats a timestamp as relative time (e.g., "2 minutes ago")
+ * @param timestamp - Unix timestamp in milliseconds
+ * @returns Formatted relative time string or "No activity yet" if undefined
+ */
+export const formatLastActivity = (timestamp: number | undefined): string => {
+  if (!timestamp) {
+    return 'No activity yet';
+  }
+  return moment(timestamp).fromNow();
+};
+
+/**
+ * Gets the most recent activity timestamp from tagActivity array
+ * @param tagActivity - Array of event models
+ * @returns Most recent timestamp or undefined if no events
+ */
+export const getLastActivityTimestamp = (tagActivity: EventModel[]): number | undefined => {
+  if (!tagActivity || tagActivity.length === 0) {
+    return undefined;
+  }
+
+  const mostRecent = tagActivity.reduce((latest, current) => {
+    return current.ts > latest.ts ? current : latest;
+  });
+
+  return mostRecent.ts;
+};

--- a/src/shared/content/appContent.ts
+++ b/src/shared/content/appContent.ts
@@ -71,6 +71,10 @@ export const appContent = {
       enabled: 'Enabled',
       disabled: 'Disabled',
       defaultStream: 'default',
+      lastActivity: 'Last Activity',
+      Requestoday: 'Request Today',
+      dataCollection: 'Data Collection',
+      active: 'Active',
     },
   },
 


### PR DESCRIPTION
<img width="352" height="171" alt="image" src="https://github.com/user-attachments/assets/7a1f83b0-d949-4550-b7d1-d6b4bd451d92" />

Added Last activity and Data collection on status page.
Last activity is based on the latest data in activity tab from debugger section.

QA steps:

try to send data from browser console through jstag.send and same should be reflected in Last activity and activity tab. This will also help to identify if the connection is ON or OFF.